### PR TITLE
Extended supported data types

### DIFF
--- a/ssc4onnx/__init__.py
+++ b/ssc4onnx/__init__.py
@@ -1,3 +1,3 @@
 from ssc4onnx.onnx_structure_check import structure_check, main
 
-__version__ = '1.0.4'
+__version__ = '1.0.5'

--- a/ssc4onnx/onnx_structure_check.py
+++ b/ssc4onnx/onnx_structure_check.py
@@ -38,10 +38,17 @@ class Color:
 
 
 ONNX_DTYPES_TO_NUMPY_DTYPES: dict = {
+    f'{onnx.TensorProto.FLOAT16}': np.float16,
     f'{onnx.TensorProto.FLOAT}': np.float32,
     f'{onnx.TensorProto.DOUBLE}': np.float64,
+    f'{onnx.TensorProto.INT8}': np.int8,
+    f'{onnx.TensorProto.INT16}': np.int16,
     f'{onnx.TensorProto.INT32}': np.int32,
     f'{onnx.TensorProto.INT64}': np.int64,
+    f'{onnx.TensorProto.UINT8}': np.uint8,
+    f'{onnx.TensorProto.UINT16}': np.uint16,
+    f'{onnx.TensorProto.UINT32}': np.uint32,
+    f'{onnx.TensorProto.UINT64}': np.uint64,
 }
 
 


### PR DESCRIPTION
```python
ONNX_DTYPES_TO_NUMPY_DTYPES: dict = {
    f'{onnx.TensorProto.FLOAT16}': np.float16,
    f'{onnx.TensorProto.FLOAT}': np.float32,
    f'{onnx.TensorProto.DOUBLE}': np.float64,
    f'{onnx.TensorProto.INT8}': np.int8,
    f'{onnx.TensorProto.INT16}': np.int16,
    f'{onnx.TensorProto.INT32}': np.int32,
    f'{onnx.TensorProto.INT64}': np.int64,
    f'{onnx.TensorProto.UINT8}': np.uint8,
    f'{onnx.TensorProto.UINT16}': np.uint16,
    f'{onnx.TensorProto.UINT32}': np.uint32,
    f'{onnx.TensorProto.UINT64}': np.uint64,
}
```